### PR TITLE
Fix stack buffer overflows in ADMesh stl_read (unbounded solid name + MW metadata parse)

### DIFF
--- a/deps_src/admesh/stlinit.cpp
+++ b/deps_src/admesh/stlinit.cpp
@@ -162,7 +162,7 @@ static bool stl_read(stl_file *stl, FILE *fp, int first_facet, bool first, Impor
         rewind(fp);
         try{
             char solid_name[256];
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_name);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_name);
             if (res_solid == 1) {
                 char* mw_position = strstr(solid_name, "MW");
                 if (mw_position != NULL) {
@@ -170,7 +170,7 @@ static bool stl_read(stl_file *stl, FILE *fp, int first_facet, bool first, Impor
                     char version_str[16];
                     char model_id_str[128]; 
                     char country_code_str[16];
-                    int num_values = sscanf(mw_position + 3, "%s %s %s", version_str, model_id_str, country_code_str);
+                    int num_values = sscanf(mw_position + 3, "%15s %127s %15s", version_str, model_id_str, country_code_str);
                     if (num_values == 3) {
                         if (strcmp(version_str, "1.0") == 0) {
                             model_id = model_id_str;


### PR DESCRIPTION
# Fix stack buffer overflows in the ADMesh ASCII-STL loader (`stl_read`)

## Summary

`stl_read()` in `deps_src/admesh/stlinit.cpp` has **two** stack buffer overflows on the ASCII-STL path, both reachable simply by opening a `.stl` file:

1. The `solid` name is copied into a fixed **256-byte** stack buffer (`solid_name[256]`) with an `fscanf` scanset that has **no field width**, so a name longer than 255 bytes overruns the buffer and the adjacent saved stack state, including the **saved return address**.

2. Immediately afterward, a `"MW"` metadata tag is parsed out of the solid name with **three unbounded `%s` conversions** into small fixed buffers (`version_str[16]`, `model_id_str[128]`, `country_code_str[16]`), overflowing those too.

## Why Elegoo is affected

Elegoo vendors the ADMesh loader (`deps_src/admesh/stlinit.cpp`) that originates in the BambuStudio tree and reaches Elegoo via OrcaSlicer. The unbounded `solid`-name `fscanf` is present at HEAD on the default branch, and so is the OrcaSlicer-added `MW` metadata parser.

## Impact

- **Memory corruption on file open** → **instruction-pointer control** (the saved return address is overwritten with attacker bytes).
- **No Pointer Authentication on the shipped macOS build**: the distributed `arm64` slice is plain `arm64` (not `arm64e`), so the saved return address is a raw, directly-usable code pointer.
- **Trivially reachable**: no user interaction beyond opening a `.stl` a user received from a third party (marketplace, shared project, print farm).

## Vulnerable code

```c
char solid_name[256];
int res_solid = fscanf(fp, " solid %[^\n]", solid_name);   // no field width
char version_str[16]; char model_id_str[128]; char country_code_str[16];
sscanf(mw_position + 3, "%s %s %s", version_str, model_id_str, country_code_str);   // three unbounded %s
```

## Proof — return address in control

Generate a cyclic (De Bruijn) `solid` name, open the file, and read the crash report's own backtrace; the saved return-address slot (frame #1) contains the pattern bytes, decoding to **solid-name offset 368**. A plain 20000×`'A'` name puts `0x414141414141` in the same slot. (Full reproducer and analysis: see the companion BambuStudio and OrcaSlicer reports linked below.)

For the second overflow, a solid name of the form `MW <t1> <t2> <t3>` drives the three `%s` conversions: `version_str[16]` overflows once the first token exceeds 15 bytes, `model_id_str[128]` on the second past 127, `country_code_str[16]` on the third past 15.

## Suggested fix (applied in this PR)

Bound every conversion with an explicit field width matching the destination:

```diff
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_name);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_name);
-                    int num_values = sscanf(mw_position + 3, "%s %s %s", version_str, model_id_str, country_code_str);
+                    int num_values = sscanf(mw_position + 3, "%15s %127s %15s", version_str, model_id_str, country_code_str);
```

`%255[^\n]` keeps the existing behavior (the name is still read) while making overflow impossible, and each `MW` token is bounded to its buffer (size − 1 for the NUL). As general hardening, every `%s`/`%[` scanset targeting a fixed buffer in this file should carry an explicit maximum field width.

## Companion reports

- Upstream fix: bambulab/BambuStudio#12153
- OrcaSlicer (also documents the `MW` overflow): OrcaSlicer/OrcaSlicer#15594

🤖 Generated with [Claude Code](https://claude.com/claude-code)